### PR TITLE
Do not re-add reviewers that have already reviewed by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ Comma separated list of GitHub usernames to be added as reviewers if creating a 
 
 Comma separated list of GitHub usernames to be added as reviewers if updating a PR.
 This will not remove any reviewers not in this list, it only ensures that reviewers
-in this list are added.
+in this list are added. If a user has already submitted a review, this action will not
+re-request a review from them, unless they are included in `update_pr_rerequest_reviewers`.
+
+### `update_pr_rerequest_reviewers`
+
+Comma separated list of GitHub usernames to request reviews from, even if they
+have already reviewed the PR.
 
 ### `create_pr_draft`
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   update_pr_reviewers:
     description: 'Comma separated list of GitHub usernames to be added as reviewers if updating a PR.'
     required: false
+  update_pr_rerequest_reviewers:
+    description: 'Comma separated list of GitHub usernames to request reviews from, even if they have already reviewed the PR.'
+    required: false
   create_pr_draft:
     description: 'Whether or not to create a draft PR, if creating a PR.'
     required: false


### PR DESCRIPTION
I discovered while using this that it is automatically re-requesting reviews when a user has submitted a review and new commits are merged into the base branch. This usually isn't desirable behavior, so the default now is to only request a review of users from which a review has not been requested and who have not submitted a review.

This also adds a secondary parameter for `update_pr_rerequest_reviewers`, for a CSV of users to request a review from even if they have already submitted a review.